### PR TITLE
Quit the app when close the main window.

### DIFF
--- a/nw-desktop-notifications.js
+++ b/nw-desktop-notifications.js
@@ -5,6 +5,10 @@
 	var counter = 0;
 	if(requireNode){
 		gui = requireNode('nw.gui');
+    var mainwin = gui.Window.get();
+    mainwin.on("close", function() {
+      gui.App.quit();
+    });
 	}
 
 	if(!window.LOCAL_NW){


### PR DESCRIPTION
The notification window is hidden, this will prevent the the whole app from quit. So we need to listen the `close` event of the main window, and quit the app. Thanks for your work. 
