### PR TITLE
Support new show_in_taskbar property in nw 0.9.2

### DIFF
--- a/nw-desktop-notifications.js
+++ b/nw-desktop-notifications.js
@@ -21,6 +21,7 @@
 			height: 0,
 			'always-on-top': true,
 			show: false,
+			show_in_taskbar: false,
 			resizable: false
 		});
 		window.LOCAL_NW.DesktopNotificationsWindow = win;


### PR DESCRIPTION
Hides the notification window from the Windows taskbar and Mac OS dock.
